### PR TITLE
It's better for task files not to include values depended the target host.

### DIFF
--- a/provision/golang.yml
+++ b/provision/golang.yml
@@ -8,7 +8,7 @@
   become: yes
 - name: Add Golang settings in .bash_profile
   blockinfile:
-    path: /home/vagrant/.bash_profile
+    path: {{ ansible_env.HOME }}/.bash_profile
     block: |
       export GOPATH=~/gowork
       export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
In this case, '/home/vagrant'(Vagrant specified value) is removed.