### PR TITLE
Save VM memory/disk size info in .vm_info.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vagrant
 ubuntu-*-cloudimg-console.log
 repos/*
+.vm_info.yml
 
 .venv_devenv/
 


### PR DESCRIPTION
- memory_size
- disk_size

These values are used when VM starts(=vagrant up).

NOTE: When this VM is provisioned on the first time,
following environment variables are used instead of above values.

- DEVENV_MEMORY_SIZE
- DEVENV_DISK_SIZE

After that, these environment variables are ignored.