### PR TITLE
Use .profile instead of .bash_profile.

### DIFF
--- a/provision/golang.yml
+++ b/provision/golang.yml
@@ -8,7 +8,7 @@
   become: yes
 - name: Add Golang settings in .bash_profile
   blockinfile:
-    path: "{{ ansible_env.HOME }}/.bash_profile"
+    path: "{{ ansible_env.HOME }}/.profile"
     block: |
       export GOPATH=~/gowork
       export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
In current main devenv(Ubuntu 18.04 vagrant box),

- .bashrc includes several convenient settings
- .profile loads .bashrc
- .profile isn't loaded when .bash_profile exists.