### PR TITLE
.profile doesn't be read if .bash_profile exists.

### DIFF
--- a/provision/main.yml
+++ b/provision/main.yml
@@ -56,7 +56,7 @@
         dest: "{{ ansible_env.HOME }}/.tmux.conf"
     - name: Add profile settings to run tmux on terminal startup
       blockinfile:
-        path: "{{ ansible_env.HOME }}/.profile"
+        path: "{{ ansible_env.HOME }}/.bash_profile"
         block: |
           if [ $SHLVL = 1 ]; then
             tmux attach || tmux


### PR DESCRIPTION
Install script of Google Cloud SDK creates .bash_profile in default.