### PR TITLE
We assume ssh agent forwarding is always used.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,4 +5,4 @@ roles_path=./roles
 ;   https://docs.ansible.com/ansible/latest/reference_appendices/config.html
 ;   https://qiita.com/taka379sy/items/331a294d67e02e18d68d
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/inventory/group_vars/github.yml
+++ b/inventory/group_vars/github.yml
@@ -1,6 +1,4 @@
 ---
 sshconfig_knownhosts:
   - github.com
-sshconfig_publickey_paths:
-  - "{{ '~/.ssh/id_rsa.pub' | expanduser }}"
 sshconfig_clientconfig_path: ../../resources/ssh_config

--- a/resources/ssh_config
+++ b/resources/ssh_config
@@ -1,8 +1,2 @@
 Host *
   UseRoaming no
-
-host github.com
-  user git
-  hostname github.com
-  identityfile ~/.ssh/id_rsa.pub
-  identitiesonly yes


### PR DESCRIPTION
- Don't set SSH key(even if public) on devenv.
- It seems that ~/.ssh/config can't refer forwarding key.