### PR TITLE
Use less as pager.

### DIFF
--- a/provision/terminal.yml
+++ b/provision/terminal.yml
@@ -23,4 +23,5 @@
     packages:
       - peco
       - xsel
+      - less
   become: yes


### PR DESCRIPTION
On GCP(Debian), more is used as default pager. But it's inconvenient
because it doesn't accept vim key-bind.(At least, on its default
settings)