### PR TITLE
Enable following APIs for periodic jobs

### DIFF
--- a/bootstrap/gcp/main.jinja
+++ b/bootstrap/gcp/main.jinja
@@ -55,3 +55,5 @@ resources:
     - cloudbuild.googleapis.com
     - cloudfunctions.googleapis.com
     - cloudkms.googleapis.com
+    - cloudscheduler.googleapis.com
+    - run.googleapis.com


### PR DESCRIPTION
- cloudscheduler.googleapis.com
- run.googleapis.com